### PR TITLE
Basic setup for using Neovim bulit-in terminal emulator

### DIFF
--- a/nvim/lua/user/general.lua
+++ b/nvim/lua/user/general.lua
@@ -48,3 +48,9 @@ vim.opt.backup = true
 
 -- keep backups out of the current directory
 vim.opt.backupdir:remove('.')
+
+-- Enter insert mode when opening or switching back to a terminal
+vim.api.nvim_create_autocmd({ 'TermOpen', 'BufEnter' }, {
+  pattern = 'term://*',
+  command = 'startinsert'
+})

--- a/nvim/lua/user/keymap.lua
+++ b/nvim/lua/user/keymap.lua
@@ -36,3 +36,7 @@ map('n', '[b', ':bprevious<cr>')
 map('n', ']b', ':bnext<cr>')
 map('n', '[B', ':bfirst<cr>')
 map('n', ']B', ':blast<cr>')
+
+-- Open a terminal in a split
+map('n', '<Leader>st', ':split | terminal<CR>')
+map('n', '<Leader>vst', ':vsplit | terminal<CR>')

--- a/nvim/lua/user/keymap.lua
+++ b/nvim/lua/user/keymap.lua
@@ -26,6 +26,10 @@ map('n', '<C-j>', '<C-w><C-j>')
 map('n', '<C-k>', '<C-w><C-k>')
 map('n', '<C-h>', '<C-w><C-h>')
 map('n', '<C-l>', '<C-w><C-l>')
+map('t', '<C-j>', '<C-\\><C-n><C-w><C-j>')
+map('t', '<C-k>', '<C-\\><C-n><C-w><C-k>')
+map('t', '<C-h>', '<C-\\><C-n><C-w><C-h>')
+map('t', '<C-l>', '<C-\\><C-n><C-w><C-l>')
 
 -- Quick switch between buffers
 map('n', '[b', ':bprevious<cr>')


### PR DESCRIPTION
- Insert mode by default when entering terminal buffer
- Use `Control`+`hjkl` key combination to navigate between windows even in terminal
- Register the keymaps `st` (split terminal) and `vsp` (vertical split terminal) to quickly open a terminal buffer