### PR TITLE
NeoVIM: Change the Typescript language server to ts_ls

### DIFF
--- a/nvim/lua/user/plugins/lspconfig.lua
+++ b/nvim/lua/user/plugins/lspconfig.lua
@@ -16,7 +16,7 @@ return {
     local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
     lspconfig.phpactor.setup { capabilities = capabilities }
-    lspconfig.tsserver.setup { capabilities = capabilities }
+    lspconfig.ts_ls.setup { capabilities = capabilities }
 
     lspconfig.tailwindcss.setup { capabilities = capabilities }
 


### PR DESCRIPTION
- Fixed the deprecation warning.