### PR TITLE
mkcd alias: create and change working directory with one command

### DIFF
--- a/.aliasrc
+++ b/.aliasrc
@@ -11,6 +11,7 @@ alias tf="terraform"
 alias dotfiles="cd $HOME/code/dotfiles"
 alias dl="cd ~/Downloads"
 alias dt="cd ~/Desktop"
+mkcd() { mkdir -p "$@" && cd $_ }
 
 # Keep system up-to-date
 # Apply updates for macOS, brew, composer and npm and their installed packages.


### PR DESCRIPTION
Example:

```bash
# mkdir -p "foo" && cd foo
mkcd foo

# mkdir -p "foo/bar baz" && cd "foo/bar baz"
mkcd "foo/bar baz"
```